### PR TITLE
Feature: cluster flag to control grouping behavior

### DIFF
--- a/main.go
+++ b/main.go
@@ -448,7 +448,7 @@ func (pbs *pbstate) showSelectedInclusion(selection string) {
 
 	backupTypes, backupInclusions := pbs.types237, pbs.inclusions
 	pbs.types237, pbs.inclusions = types, inclusions
-	pbs.showInclusion(false, true)
+	pbs.showInclusion(*g_cluster, true)
 	pbs.types237, pbs.inclusions = backupTypes, backupInclusions
 }
 
@@ -1331,7 +1331,7 @@ func process(pbs *pbstate, name string, selection string) bool {
 				pbs.showSelectedInclusion(selection)
 			}
 		} else {
-			pbs.showInclusion(true, true)
+			pbs.showInclusion(*g_cluster, true)
 		}
 
 	} else {
@@ -1395,6 +1395,8 @@ func applyToAllFilesFromList(listfilename string, selection string) {
 const configDefaultName = "config.json"
 
 var (
+	g_cluster    = flag.Bool("cluster", true, "Cluster elements from the same package together")
+
 	g_action     = flag.String("action", "", "Custom action to run upon completion (overwrites config.locations.action)")
 	g_configPath = flag.String("config", configDefaultName, "Location and name of the configuration file")
 	g_grpc       = flag.String("grpc", "", "Port to listen, e.g. :50051")

--- a/main.go
+++ b/main.go
@@ -1395,13 +1395,13 @@ func applyToAllFilesFromList(listfilename string, selection string) {
 const configDefaultName = "config.json"
 
 var (
+	g_action     = flag.String("action", "", "Custom action to run upon completion (overwrites config.locations.action)")
 	g_configPath = flag.String("config", configDefaultName, "Location and name of the configuration file")
-	g_logPath    = flag.String("log", "", "Location and name of the debug log file")
-	g_source     = flag.String("src", "", "Location and name of the source file (required)")
-	g_selection  = flag.String("select", "", "Name(s) of the selected elements")
-	g_output     = flag.String("output", "", "Name of the output file")
 	g_grpc       = flag.String("grpc", "", "Port to listen, e.g. :50051")
-	g_action     = flag.String("action", "", "custom action to run upon completion (overwrites config.locations.action)")
+	g_logPath    = flag.String("log", "", "Location and name of the debug log file")
+	g_output     = flag.String("output", "", "Name of the output file")
+	g_selection  = flag.String("select", "", "Name(s) of the selected elements")
+	g_source     = flag.String("src", "", "Location and name of the source file (required)")
 )
 
 //======================================================================================================================


### PR DESCRIPTION
At the moment the user has to use the -select argument to prevent the background clustering (even if they want the complete UML) and there is no way to activate clustering if they are selecting the elements they want to show in the UML.

This -cluster flag lets the user switch on/off the clustering background in all cases. 

It is on by default (which is the current default behavior for complete UML generation) and the user can supply -cluster=false to deactivate grouping of elements belonging to the same module/file.